### PR TITLE
Devolutions.TranslationTool.exe v1.0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 .DS_Store
 .cache
+.translation-tool

--- a/translation-tool/.gitignore
+++ b/translation-tool/.gitignore
@@ -1,0 +1,5 @@
+.vs/
+**/bin/
+**/obj/
+**/*.user
+**/secrets.json

--- a/translation-tool/DeeplIgnoreTag.cs
+++ b/translation-tool/DeeplIgnoreTag.cs
@@ -1,0 +1,13 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.Text.RegularExpressions;
+
+internal static partial class DeeplIgnoreTag
+{
+    public const string Name = "x";
+    public const string Begin = $"<{Name}>";
+    public const string End = $"</{Name}>";
+
+    [GeneratedRegex($@"{Begin}(\d+){End}", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    public static partial Regex GetSubstitutionRegex();
+}

--- a/translation-tool/DeeplTranslation.cs
+++ b/translation-tool/DeeplTranslation.cs
@@ -1,0 +1,11 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class DeeplTranslation
+{
+    public DeeplTranslation(string text) =>
+        this.Text = text ?? throw new ArgumentNullException(nameof(text));
+
+    public string Text { get; }
+
+    public string? Result { get; set; }
+}

--- a/translation-tool/Devolutions.TranslationTool.csproj
+++ b/translation-tool/Devolutions.TranslationTool.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NeutralLanguage>en</NeutralLanguage>
+    <OutputPath>bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="DeepL.net" Version="1.7.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
+    <PackageReference Include="Markdig" Version="0.31.0" />
+  </ItemGroup>
+
+</Project>

--- a/translation-tool/Devolutions.TranslationTool.sln
+++ b/translation-tool/Devolutions.TranslationTool.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33502.453
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Devolutions.TranslationTool", "Devolutions.TranslationTool.csproj", "{8632E271-1097-4189-B03A-D38637443BBF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8632E271-1097-4189-B03A-D38637443BBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8632E271-1097-4189-B03A-D38637443BBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8632E271-1097-4189-B03A-D38637443BBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8632E271-1097-4189-B03A-D38637443BBF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CA6231AB-F010-4FFD-ACFC-F913F5C0FBD9}
+	EndGlobalSection
+EndGlobal

--- a/translation-tool/Devolutions.TranslationTool.sln.DotSettings
+++ b/translation-tool/Devolutions.TranslationTool.sln.DotSettings
@@ -1,0 +1,25 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">Latest</s:String>
+    <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FBuiltInTypes/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FElsewhere/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FSimpleTypes/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuspiciousTypeConversion_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">Field, Property, Event, Method</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForBuiltInTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CR/@EntryIndexedValue">CR</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CRLF/@EntryIndexedValue">CRLF</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EOL/@EntryIndexedValue">EOL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LF/@EntryIndexedValue">LF</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/ExternalSources/Decompiler/DecompilerLegalNoticeAccepted/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=deepl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Devolutions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Renderers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unshareable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/translation-tool/FileTranslator.cs
+++ b/translation-tool/FileTranslator.cs
@@ -1,0 +1,385 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using DeepL;
+using DeepL.Model;
+
+using Markdig;
+using Markdig.Syntax;
+
+using Renderers;
+
+internal sealed partial class FileTranslator
+{
+    private const int TranslationsInitialCapacity = 1024;
+    private const int SubstitutionsInitialCapacity = 1024;
+
+    private readonly Encoding targetEncoding;
+    private readonly TargetFile targetFile;
+    private readonly MarkdownPipeline markdownPipeline;
+    private readonly Translator deeplTranslator;
+    private readonly TextTranslateOptions deeplTextTranslateOptions;
+    private readonly Dictionary<string, string> completedTranslations;
+
+    private string sourceFileContent = null!;
+    private string sourceFileEOL = null!;
+    private Dictionary<string, DeeplTranslation> translations = null!;
+    private Dictionary<int, ISubstitution> substitutions = null!;
+    private string sourceFileContentWithoutHeader = null!;
+    private string targetFileHeader = null!;
+    private string nonTranslatedTargetFileContentWithoutHeader = null!;
+    private string targetFileContent = null!;
+
+    public FileTranslator(Encoding targetEncoding, TargetFile targetFile, MarkdownPipeline markdownPipeline, Translator deeplTranslator,
+        TextTranslateOptions deeplTextTranslateOptions, Dictionary<string, string> completedTranslations)
+    {
+        this.targetEncoding = targetEncoding ?? throw new ArgumentNullException(nameof(targetEncoding));
+        this.targetFile = targetFile ?? throw new ArgumentNullException(nameof(targetFile));
+        this.markdownPipeline = markdownPipeline ?? throw new ArgumentNullException(nameof(markdownPipeline));
+        this.deeplTranslator = deeplTranslator ?? throw new ArgumentNullException(nameof(deeplTranslator));
+        this.deeplTextTranslateOptions = deeplTextTranslateOptions ?? throw new ArgumentNullException(nameof(deeplTextTranslateOptions));
+        this.completedTranslations = completedTranslations ?? throw new ArgumentNullException(nameof(completedTranslations));
+    }
+
+    public async Task Execute()
+    {
+        await this.ReadSourceFile().ConfigureAwait(false);
+        this.FindSourceFileEOL();
+        this.ExtractHeaderFromSourceFile();
+        await this.ParseSourceFile().ConfigureAwait(false);
+        await this.Translate().ConfigureAwait(false);
+        this.AssembleTargetFile();
+        await this.WriteTargetFile().ConfigureAwait(false);
+    }
+
+    private async Task ReadSourceFile() =>
+        this.sourceFileContent = await File.ReadAllTextAsync(this.targetFile.SourceFile.FilePath).ConfigureAwait(false);
+
+    private void FindSourceFileEOL()
+    {
+        SourceFile sourceFile = this.targetFile.SourceFile;
+        if (sourceFile.EOL == null)
+        {
+            Match match = FindEOLRegex().Match(this.sourceFileContent);
+            sourceFile.EOL = match.Success ? match.Value : "\r\n";
+        }
+
+        this.sourceFileEOL = sourceFile.EOL;
+    }
+
+    [GeneratedRegex(@"\r?\n|\r", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex FindEOLRegex();
+
+    private void ExtractHeaderFromSourceFile()
+    {
+        this.translations = new Dictionary<string, DeeplTranslation>(TranslationsInitialCapacity, StringComparer.Ordinal);
+        this.substitutions = new Dictionary<int, ISubstitution>(SubstitutionsInitialCapacity);
+        string latestCommitHeaderLine = $"latestCommit: {this.targetFile.SourceFile.LatestCommit}{this.sourceFileEOL}";
+        Match headerMatch = GetHeaderRegex().Match(this.sourceFileContent);
+        if (headerMatch.Success)
+        {
+            this.sourceFileContentWithoutHeader = this.sourceFileContent[headerMatch.Length..];
+
+            string sourceFileHeaderPart1 = headerMatch.Groups[1].Value;
+            string sourceFileHeaderPart2 = headerMatch.Groups[2].Value;
+
+            string targetFileHeaderPart1 = TitleLineRegex().Replace(sourceFileHeaderPart1, this.ReplaceTitleLineRegex, 1);
+            targetFileHeaderPart1 = DescriptionLineRegex().Replace(targetFileHeaderPart1, this.ReplaceDescriptionLineRegex, 1);
+            targetFileHeaderPart1 = KeywordsLinesRegex().Replace(targetFileHeaderPart1, this.ReplaceKeywordsLinesRegex, 1);
+            targetFileHeaderPart1 = LatestCommitLineRegex().Replace(targetFileHeaderPart1, this.sourceFileEOL, 1);
+
+            this.targetFileHeader = $"{targetFileHeaderPart1}{latestCommitHeaderLine}{sourceFileHeaderPart2}";
+        }
+        else
+        {
+            this.sourceFileContentWithoutHeader = this.sourceFileContent;
+            this.targetFileHeader = $"---{this.sourceFileEOL}{latestCommitHeaderLine}---{this.sourceFileEOL}";
+        }
+    }
+
+    [GeneratedRegex(@"^(---(?:\r?\n|\r).*?(?:\r?\n|\r))(---(?:\r?\n|\r)+)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex GetHeaderRegex();
+
+    [GeneratedRegex(@"(?:\r?\n|\r) *title:([^\r\n]*)(?:\r?\n|\r)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex TitleLineRegex();
+
+    private string ReplaceTitleLineRegex(Match match)
+    {
+        string title = match.Groups[1].Value.Trim();
+        if (string.IsNullOrEmpty(title))
+        {
+            return this.sourceFileEOL;
+        }
+
+        title = this.ProcessSourceFileText(title);
+        return $"{this.sourceFileEOL}title: {title}{this.sourceFileEOL}";
+    }
+
+    [GeneratedRegex(@"(?:\r?\n|\r) *description:([^\r\n]*)(?:\r?\n|\r)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex DescriptionLineRegex();
+
+    private string ReplaceDescriptionLineRegex(Match match)
+    {
+        string description = match.Groups[1].Value.Trim();
+        if (string.IsNullOrEmpty(description))
+        {
+            return this.sourceFileEOL;
+        }
+
+        description = this.ProcessSourceFileText(description);
+        return $"{this.sourceFileEOL}description: {description}{this.sourceFileEOL}";
+    }
+
+    [GeneratedRegex(@"(?:\r?\n|\r) *keywords:[^\r\n]*(?:\r?\n|\r)(?: *-([^\r\n]*)(?:\r?\n|\r))*", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex KeywordsLinesRegex();
+
+    private string ReplaceKeywordsLinesRegex(Match match)
+    {
+        CaptureCollection captures = match.Groups[1].Captures;
+        if (captures.Count == 0)
+        {
+            return this.sourceFileEOL;
+        }
+
+        bool atLeastOneKeyword = false;
+        StringBuilder keywordsLinesBuilder = new(512);
+        keywordsLinesBuilder.Append($"{this.sourceFileEOL}keywords:{this.sourceFileEOL}");
+        foreach (Capture capture in (IEnumerable<Capture>)captures)
+        {
+            string keyword = capture.Value.Trim();
+            if (string.IsNullOrEmpty(keyword))
+            {
+                continue;
+            }
+
+            keyword = this.ProcessSourceFileText(keyword);
+            keywordsLinesBuilder.Append($"- {keyword}{this.sourceFileEOL}");
+            atLeastOneKeyword = true;
+        }
+
+        return atLeastOneKeyword ? keywordsLinesBuilder.ToString() : this.sourceFileEOL;
+    }
+
+    [GeneratedRegex(@"(?:\r?\n|\r) *latestCommit:[^\r\n]*(?:\r?\n|\r)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex LatestCommitLineRegex();
+
+    private async Task ParseSourceFile()
+    {
+        StringWriter writer = new(new StringBuilder(this.sourceFileContentWithoutHeader.Length), CultureInfo.InvariantCulture);
+        await using (writer.ConfigureAwait(false))
+        {
+            TargetFileRenderer renderer = new(writer, this.sourceFileContentWithoutHeader, this.ProcessSourceFileText);
+            MarkdownDocument document = Markdown.Parse(this.sourceFileContentWithoutHeader, this.markdownPipeline);
+            renderer.Render(document);
+
+            // Flush any remaining markdown content
+            await renderer.Writer.WriteAsync(renderer.TakeNext(this.sourceFileContentWithoutHeader.Length - renderer.LastWrittenIndex)).ConfigureAwait(false);
+
+            this.nonTranslatedTargetFileContentWithoutHeader = writer.ToString();
+        }
+    }
+
+    private string ProcessSourceFileText(string sourceFileText)
+    {
+        if (string.IsNullOrEmpty(sourceFileText))
+        {
+            return string.Empty;
+        }
+
+        string text = sourceFileText;
+        text = LinkRegex().Replace(text, this.ReplaceLink);
+        text = EmphasisRegex().Replace(text, this.ReplaceEmphasis);
+        text = SnippetRegex().Replace(text, this.ReplaceSnippet);
+        text = VariableRegex().Replace(text, this.ReplaceVariable);
+
+        return this.QueueTranslation(text);
+    }
+
+    [GeneratedRegex(@"(!?\[ *)([^\r\n\]]*?)( *\]\([^\r\n\)]*\))", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex LinkRegex();
+
+    private string ReplaceLink(Match match)
+    {
+        string link = match.Groups[2].Value;
+        if (link.StartsWith("!!", StringComparison.Ordinal) || link.Length > 4 && link[^4] == '.')
+        {
+            // This is a filename, do not translate
+            return this.AddTextSubstitution(match.Value);
+        }
+
+        string part1 = this.AddTextSubstitution(match.Groups[1].Value);
+        string part2 = this.ProcessSourceFileText(link);
+        string part3 = this.AddTextSubstitution(match.Groups[3].Value);
+        return $"{part1}{part2}{part3}";
+    }
+
+    [GeneratedRegex(@"(\*\*\* *)([^\r\n\*]*?)( *\*\*\*)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex EmphasisRegex();
+
+    private string ReplaceEmphasis(Match match)
+    {
+        string part1 = this.AddTextSubstitution(match.Groups[1].Value);
+        string part2 = this.ProcessSourceFileText(match.Groups[2].Value);
+        string part3 = this.AddTextSubstitution(match.Groups[3].Value);
+        return $"{part1}{part2}{part3}";
+    }
+
+    [GeneratedRegex(@"\{% *(?i:snippet|endsnippet)[^\r\n%]*%\}", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex SnippetRegex();
+
+    private string ReplaceSnippet(Match match) => this.AddTextSubstitution(match.Value);
+
+    [GeneratedRegex($@"(\{{\{{ *)(?i:{LanguageCode.English}|{LanguageCode.French}|{LanguageCode.German})(\.[^\r\n\}}]*\}}\}})", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex VariableRegex();
+
+    private string ReplaceVariable(Match match) =>
+        this.AddTextSubstitution($"{match.Groups[1].Value}{this.targetFile.Language.Code}{match.Groups[2].Value}");
+
+    private string QueueTranslation(string text)
+    {
+        Match trimSubstitutionsMatch = TrimSubstitutionsRegex().Match(text);
+
+        // Ignore tags at the start, along with space characters, do not have to be translated
+        string beginPart = string.Empty;
+        string trimmedAtStart = trimSubstitutionsMatch.Groups[1].Value;
+        if (!string.IsNullOrEmpty(trimmedAtStart))
+        {
+            beginPart = this.AddTextSubstitution(trimmedAtStart);
+        }
+
+        // Ignore tags at the end, along with space characters, do not have to be translated
+        string endPart = string.Empty;
+        string trimmedAtEnd = trimSubstitutionsMatch.Groups[3].Value;
+        if (!string.IsNullOrEmpty(trimmedAtEnd))
+        {
+            endPart = this.AddTextSubstitution(trimmedAtEnd);
+        }
+
+        string middlePart = string.Empty;
+        string textToTranslate = trimSubstitutionsMatch.Groups[2].Value;
+        if (!string.IsNullOrEmpty(textToTranslate))
+        {
+            if (!DeeplIgnoreTag.GetSubstitutionRegex().Replace(textToTranslate, string.Empty).Any(char.IsLetter))
+            {
+                // No letter when the ignore tags are removed, so not something we have to translate
+                middlePart = this.AddTextSubstitution(textToTranslate);
+            }
+            else
+            {
+                // When multiple substitutions are following each other, we must replace them by a single one,
+                // otherwise the translation may add spaces we do not want
+                textToTranslate = ConsecutiveSubstitutionsRegex().Replace(textToTranslate, this.CombineConsecutiveSubstitutions);
+
+                // If the text to translate has substitutions, normalizing it (by changing indexes in ignore tags to 0, 1, 2, 3, etc.)
+                // drastically improves the likelihood of reusing that translation elsewhere
+                List<int> substitutionIndexes = new();
+                string normalizedTextToTranslate = DeeplIgnoreTag.GetSubstitutionRegex().Replace(textToTranslate, match =>
+                {
+                    if (int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int index))
+                    {
+                        string replacement = $"{DeeplIgnoreTag.Begin}{substitutionIndexes.Count}{DeeplIgnoreTag.End}";
+                        substitutionIndexes.Add(index);
+                        return replacement;
+                    }
+
+                    return match.Value;
+                });
+
+                if (this.completedTranslations.TryGetValue(normalizedTextToTranslate, out string? translatedText))
+                {
+                    // That translation already has been completed for another file or was in the cache
+                    // However, we need to set the right ignore tag indexes in the translated text
+                    translatedText = DeeplIgnoreTag.GetSubstitutionRegex().Replace(translatedText, match =>
+                        int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int index) &&
+                        index < substitutionIndexes.Count ? $"{DeeplIgnoreTag.Begin}{substitutionIndexes[index]}{DeeplIgnoreTag.End}" : match.Value);
+
+                    middlePart = this.AddTextSubstitution(translatedText);
+                }
+                else
+                {
+                    // If the same translation has to be done more than once, reuse it
+                    if (!this.translations.TryGetValue(normalizedTextToTranslate, out DeeplTranslation? translation))
+                    {
+                        translation = new DeeplTranslation(normalizedTextToTranslate);
+                        this.translations.Add(normalizedTextToTranslate, translation);
+                    }
+
+                    middlePart = this.AddTranslationSubstitution(translation, substitutionIndexes);
+                }
+            }
+        }
+
+        return $"{beginPart}{middlePart}{endPart}";
+    }
+
+    public const string GetSubstitutionPattern = $@"{DeeplIgnoreTag.Begin}\d+{DeeplIgnoreTag.End}";
+
+    [GeneratedRegex($@"^((?:\s+|{GetSubstitutionPattern})*)(.*?)((?:\s+|{GetSubstitutionPattern})*)$", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex TrimSubstitutionsRegex();
+
+    [GeneratedRegex($@"{DeeplIgnoreTag.Begin}\d+{DeeplIgnoreTag.End}(?:\s*{DeeplIgnoreTag.Begin}\d+{DeeplIgnoreTag.End})+", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex ConsecutiveSubstitutionsRegex();
+
+    private string CombineConsecutiveSubstitutions(Match match) => this.AddTextSubstitution(match.Value);
+
+    private string AddTextSubstitution(string text)
+    {
+        int substitutionIndex = this.substitutions.Count;
+        string substitutionTag = $"{DeeplIgnoreTag.Begin}{substitutionIndex}{DeeplIgnoreTag.End}";
+        this.substitutions.Add(substitutionIndex, new TextSubstitution(text, this.substitutions));
+        return substitutionTag;
+    }
+
+    public string AddTranslationSubstitution(DeeplTranslation translation, IList<int> substitutionIndexes)
+    {
+        int substitutionIndex = this.substitutions.Count;
+        string substitutionTag = $"{DeeplIgnoreTag.Begin}{substitutionIndex}{DeeplIgnoreTag.End}";
+        this.substitutions.Add(substitutionIndex, new TranslationSubstitution(translation, substitutionIndexes, this.substitutions));
+        return substitutionTag;
+    }
+
+    private async Task Translate()
+    {
+        if (this.translations.Count == 0)
+        {
+            return;
+        }
+
+        // The order of the keys in the Dictionary<TKey,TValue>.KeyCollection is unspecified, but it is the same order as the associated values
+        // in the Dictionary<TKey,TValue>.ValueCollection returned by the Values property
+        Dictionary<string, DeeplTranslation>.KeyCollection keys = this.translations.Keys;
+        Dictionary<string, DeeplTranslation>.ValueCollection values = this.translations.Values;
+
+        TextResult[] results = await this.deeplTranslator.TranslateTextAsync(keys, LanguageCode.English,
+            LanguageCode.French, this.deeplTextTranslateOptions).ConfigureAwait(false);
+
+        if (results.Length != this.translations.Count)
+        {
+            throw new InvalidOperationException(
+                $"Expected to receive {this.translations.Count} results, but received {results.Length} results instead");
+        }
+
+        int index = 0;
+        foreach (DeeplTranslation translation in values)
+        {
+            this.completedTranslations.Add(translation.Text, translation.Result = results[index].Text);
+            index++;
+        }
+    }
+
+    private void AssembleTargetFile()
+    {
+        string nonTranslatedTargetFileContent = $"{this.targetFileHeader}{this.nonTranslatedTargetFileContentWithoutHeader}";
+        TextSubstitution substitution = new(nonTranslatedTargetFileContent, this.substitutions);
+        this.targetFileContent = substitution.GetReplacement();
+    }
+
+    private async Task WriteTargetFile()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(this.targetFile.FilePath)!);
+        await File.WriteAllTextAsync(this.targetFile.FilePath, this.targetFileContent, this.targetEncoding).ConfigureAwait(false);
+    }
+}

--- a/translation-tool/ISubstitution.cs
+++ b/translation-tool/ISubstitution.cs
@@ -1,0 +1,6 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal interface ISubstitution
+{
+    string GetReplacement();
+}

--- a/translation-tool/LanguageTranslator.cs
+++ b/translation-tool/LanguageTranslator.cs
@@ -1,0 +1,95 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.Text;
+using System.Text.Json;
+
+using DeepL;
+
+using Markdig;
+
+internal sealed class LanguageTranslator
+{
+    private const int CompletedTranslationsInitialCapacity = 65536;
+
+    private readonly Encoding targetEncoding;
+    private readonly TargetLanguage targetLanguage;
+    private readonly MarkdownPipeline markdownPipeline;
+    private readonly Translator deeplTranslator;
+    private readonly TranslatedFileCounter translatedFileCounter;
+
+    // TODO Set GlossaryId here
+    private readonly TextTranslateOptions deeplTextTranslateOptions = new()
+    {
+        Formality = Formality.PreferMore,
+        IgnoreTags = { DeeplIgnoreTag.Name },
+        PreserveFormatting = true,
+        TagHandling = "xml"
+    };
+
+    public LanguageTranslator(Encoding targetEncoding, TargetLanguage targetLanguage, MarkdownPipeline markdownPipeline,
+        Translator deeplTranslator, TranslatedFileCounter translatedFileCounter)
+    {
+        this.targetEncoding = targetEncoding ?? throw new ArgumentNullException(nameof(targetEncoding));
+        this.targetLanguage = targetLanguage ?? throw new ArgumentNullException(nameof(targetLanguage));
+        this.markdownPipeline = markdownPipeline ?? throw new ArgumentNullException(nameof(markdownPipeline));
+        this.deeplTranslator = deeplTranslator ?? throw new ArgumentNullException(nameof(deeplTranslator));
+        this.translatedFileCounter = translatedFileCounter ?? throw new ArgumentNullException(nameof(translatedFileCounter));
+    }
+
+    public async Task Execute()
+    {
+        Dictionary<string, string> completedTranslations = await this.LoadCache().ConfigureAwait(false);
+        try
+        {
+            foreach (TargetFile targetFile in this.targetLanguage.Files)
+            {
+                FileTranslator fileTranslator = new(this.targetEncoding, targetFile, this.markdownPipeline,
+                    this.deeplTranslator, this.deeplTextTranslateOptions, completedTranslations);
+                await fileTranslator.Execute().ConfigureAwait(false);
+                this.translatedFileCounter.Increment();
+                if (this.translatedFileCounter.MaximumReached)
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            await this.SaveCache(completedTranslations).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<Dictionary<string, string>> LoadCache()
+    {
+        try
+        {
+            FileStream fileStream = new(this.targetLanguage.CacheFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            await using (fileStream.ConfigureAwait(false))
+            {
+                return await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(fileStream).ConfigureAwait(false) ??
+                       new Dictionary<string, string>(CompletedTranslationsInitialCapacity, StringComparer.Ordinal);
+            }
+        }
+        catch
+        {
+            return new Dictionary<string, string>(CompletedTranslationsInitialCapacity, StringComparer.Ordinal);
+        }
+    }
+
+    private async Task SaveCache(Dictionary<string, string> completedTranslations)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(this.targetLanguage.CacheFilePath)!);
+            FileStream fileStream = new(this.targetLanguage.CacheFilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await using (fileStream.ConfigureAwait(false))
+            {
+                await JsonSerializer.SerializeAsync(fileStream, completedTranslations, new JsonSerializerOptions { WriteIndented = true }).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // Ignored
+        }
+    }
+}

--- a/translation-tool/Program.cs
+++ b/translation-tool/Program.cs
@@ -1,0 +1,6 @@
+﻿using CommandLine;
+
+using Devolutions.TranslationTool;
+
+await Parser.Default.ParseArguments<ProgramOptions>(args).WithParsedAsync(options => new RepositoryTranslator(
+    options.DeeplAuthenticationKey, options.SourceLanguageCode, options.TargetLanguageCodes.ToArray(), options.MaxTranslatedFileCount).Execute());

--- a/translation-tool/ProgramOptions.cs
+++ b/translation-tool/ProgramOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace Devolutions.TranslationTool;
+
+using CommandLine;
+
+using DeepL;
+
+public sealed class ProgramOptions
+{
+    [Option('k', "key", Required = true, HelpText = "DeepL authentication key used to call the API")]
+    public string DeeplAuthenticationKey { get; set; } = null!;
+
+    [Option('s', "source", Required = false, Default = LanguageCode.English, HelpText = "Source language code")]
+    public string SourceLanguageCode { get; set; } = null!;
+
+    [Option('t', "target", Required = false, Default = new[] { LanguageCode.French }, HelpText = "Target language codes (e.g. fr, de, fr de)")]
+    public IEnumerable<string> TargetLanguageCodes { get; set; } = null!;
+
+    [Option('m', "max", Required = false, Default = int.MaxValue, HelpText = "Maximum translated file count")]
+    public int MaxTranslatedFileCount { get; set; }
+}

--- a/translation-tool/Properties/launchSettings.json
+++ b/translation-tool/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Devolutions.TranslationTool": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/translation-tool/Renderers/ContainerBlockRenderer.cs
+++ b/translation-tool/Renderers/ContainerBlockRenderer.cs
@@ -1,0 +1,9 @@
+﻿namespace Devolutions.TranslationTool.Renderers;
+
+using Markdig.Renderers;
+using Markdig.Syntax;
+
+internal sealed class ContainerBlockRenderer : MarkdownObjectRenderer<TargetFileRenderer, ContainerBlock>
+{
+    protected override void Write(TargetFileRenderer renderer, ContainerBlock containerBlock) => renderer.WriteChildren(containerBlock);
+}

--- a/translation-tool/Renderers/ContainerInlineRenderer.cs
+++ b/translation-tool/Renderers/ContainerInlineRenderer.cs
@@ -1,0 +1,39 @@
+﻿namespace Devolutions.TranslationTool.Renderers;
+
+using Markdig.Renderers;
+using Markdig.Syntax.Inlines;
+
+internal sealed class ContainerInlineRenderer : MarkdownObjectRenderer<TargetFileRenderer, ContainerInline>
+{
+    private readonly Func<string, string> processSourceFileTextFunc;
+
+    public ContainerInlineRenderer(Func<string, string> processSourceFileTextFunc) =>
+        this.processSourceFileTextFunc = processSourceFileTextFunc ?? throw new ArgumentNullException(nameof(processSourceFileTextFunc));
+
+    protected override void Write(TargetFileRenderer renderer, ContainerInline containerInline)
+    {
+        int startIndex = containerInline.Span.Start;
+
+        int difference1 = startIndex - renderer.LastWrittenIndex;
+        if (difference1 > 0)
+        {
+            // Make sure we flush all previous markdown before rendering this inline entry
+            renderer.Write(renderer.TakeNext(difference1));
+        }
+
+        if (containerInline.LastChild == null)
+        {
+            return;
+        }
+
+        int difference2 = containerInline.LastChild.Span.End + 1 - startIndex;
+        if (difference2 <= 0)
+        {
+            return;
+        }
+
+        string sourceFileText = renderer.TakeNext(difference2);
+        string targetFileText = this.processSourceFileTextFunc(sourceFileText);
+        renderer.Write(targetFileText);
+    }
+}

--- a/translation-tool/Renderers/LeafBlockRenderer.cs
+++ b/translation-tool/Renderers/LeafBlockRenderer.cs
@@ -1,0 +1,9 @@
+﻿namespace Devolutions.TranslationTool.Renderers;
+
+using Markdig.Renderers;
+using Markdig.Syntax;
+
+internal sealed class LeafBlockRenderer : MarkdownObjectRenderer<TargetFileRenderer, LeafBlock>
+{
+    protected override void Write(TargetFileRenderer renderer, LeafBlock leafBlock) => renderer.WriteLeafInline(leafBlock);
+}

--- a/translation-tool/Renderers/TargetFileRenderer.cs
+++ b/translation-tool/Renderers/TargetFileRenderer.cs
@@ -1,0 +1,30 @@
+﻿namespace Devolutions.TranslationTool.Renderers;
+
+using Markdig.Renderers;
+
+internal sealed class TargetFileRenderer : TextRendererBase<TargetFileRenderer>
+{
+    public TargetFileRenderer(TextWriter writer, string sourceFileContent, Func<string, string> processSourceFileTextFunc) : base(writer)
+    {
+        this.SourceFileContent = sourceFileContent;
+        this.ObjectRenderers.Add(new ContainerBlockRenderer());
+        this.ObjectRenderers.Add(new LeafBlockRenderer());
+        this.ObjectRenderers.Add(new ContainerInlineRenderer(processSourceFileTextFunc));
+    }
+
+    public string SourceFileContent { get; }
+
+    public int LastWrittenIndex { get; private set; }
+
+    public string TakeNext(int length)
+    {
+        if (length == 0)
+        {
+            return string.Empty;
+        }
+
+        string result = this.SourceFileContent.Substring(this.LastWrittenIndex, length);
+        this.LastWrittenIndex += length;
+        return result;
+    }
+}

--- a/translation-tool/RepositoryTranslator.cs
+++ b/translation-tool/RepositoryTranslator.cs
@@ -1,0 +1,198 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using DeepL;
+
+using LibGit2Sharp;
+
+using Markdig;
+
+public sealed partial class RepositoryTranslator
+{
+    private readonly string deeplAuthenticationKey;
+    private readonly string sourceLanguageCode;
+    private readonly string[] targetLanguageCodes;
+    private readonly int maxTranslatedFileCount;
+    private readonly Encoding targetEncoding = new UTF8Encoding(false, true);
+    private readonly TranslatorOptions deeplTranslatorOptions = new()
+    {
+        appInfo = new AppInfo { AppName = "Devolutions.TranslationTool", AppVersion = "1.0.0" },
+        MaximumNetworkRetries = 3,
+        OverallConnectionTimeout = TimeSpan.FromSeconds(60d),
+        PerRetryConnectionTimeout = TimeSpan.FromSeconds(30d),
+        sendPlatformInfo = true
+    };
+
+    public RepositoryTranslator(string deeplAuthenticationKey, string sourceLanguageCode, string[] targetLanguageCodes, int maxTranslatedFileCount = int.MaxValue)
+    {
+        if (maxTranslatedFileCount < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTranslatedFileCount));
+        }
+
+        this.deeplAuthenticationKey = deeplAuthenticationKey ?? throw new ArgumentNullException(nameof(deeplAuthenticationKey));
+        this.sourceLanguageCode = sourceLanguageCode ?? throw new ArgumentNullException(nameof(sourceLanguageCode));
+        this.targetLanguageCodes = targetLanguageCodes ?? throw new ArgumentNullException(nameof(targetLanguageCodes));
+        this.maxTranslatedFileCount = maxTranslatedFileCount;
+    }
+
+    public async Task Execute()
+    {
+        string repositoryPath = this.GetRepositoryPath();
+        SourceLanguage sourceLanguage = this.GetSourceLanguage(repositoryPath);
+        TargetLanguage[] targetLanguages = await this.GetTargetLanguages(repositoryPath, sourceLanguage).ConfigureAwait(false);
+        MarkdownPipeline markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+        using Translator deeplTranslator = new(this.deeplAuthenticationKey, this.deeplTranslatorOptions);
+        TranslatedFileCounter translatedFileCounter = new(this.maxTranslatedFileCount);
+        foreach (TargetLanguage targetLanguage in targetLanguages)
+        {
+            LanguageTranslator languageTranslator = new(this.targetEncoding, targetLanguage, markdownPipeline, deeplTranslator, translatedFileCounter);
+            await languageTranslator.Execute().ConfigureAwait(false);
+            if (translatedFileCounter.MaximumReached)
+            {
+                break;
+            }
+        }
+    }
+
+    private string GetRepositoryPath()
+    {
+        string directoryPath = Directory.GetCurrentDirectory();
+        DirectoryInfo? directoryInfo = new(directoryPath);
+        do
+        {
+            directoryPath = directoryInfo.FullName;
+            if (Directory.Exists(Path.Combine(directoryInfo.FullName, "docs")))
+            {
+                return directoryPath;
+            }
+
+            directoryInfo = directoryInfo.Parent;
+        }
+        while (directoryInfo != null);
+        throw new InvalidOperationException("Current directory is not within the expected repository");
+    }
+
+    private SourceLanguage GetSourceLanguage(string repositoryPath)
+    {
+        SourceLanguage sourceLanguage = new(this.sourceLanguageCode, Path.Combine(repositoryPath, "docs", this.sourceLanguageCode));
+        sourceLanguage.Files = GetSourceFiles(repositoryPath, sourceLanguage);
+        return sourceLanguage;
+    }
+
+    private static SourceFile[] GetSourceFiles(string repositoryPath, SourceLanguage sourceLanguage)
+    {
+        string[] sourceFilePaths = Directory.GetFiles(sourceLanguage.DirectoryPath, "*.md", SearchOption.AllDirectories);
+
+        using Repository repository = new(repositoryPath);
+        Commit latestCommit = repository.Head.Tip;
+
+        List<SourceFile> result = new(sourceFilePaths.Length);
+        foreach (string sourceFilePath in sourceFilePaths)
+        {
+            string? latestCommitFromGit = GetLatestCommitFromGit(repositoryPath, latestCommit, sourceFilePath);
+            if (latestCommitFromGit != null)
+            {
+                result.Add(new SourceFile(sourceLanguage, sourceFilePath, latestCommitFromGit));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    private static string? GetLatestCommitFromGit(string repositoryPath, Commit latestCommit, string filePath)
+    {
+        string relativeFilePath = filePath.Replace(repositoryPath, string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace('\\', '/').TrimStart('/');
+
+        Commit commit = latestCommit;
+        GitObject? gitObject = commit[relativeFilePath]?.Target;
+        if (gitObject == null)
+        {
+            return null;
+        }
+
+        HashSet<string> hashSet = new();
+        Queue<Commit> queue = new();
+        queue.Enqueue(commit);
+        hashSet.Add(commit.Sha);
+
+        while (queue.Count > 0)
+        {
+            commit = queue.Dequeue();
+            bool dequeue = false;
+            foreach (Commit parent in commit.Parents)
+            {
+                TreeEntry? treeEntry = parent[relativeFilePath];
+                if (treeEntry == null)
+                {
+                    continue;
+                }
+
+                bool equals = string.Equals(treeEntry.Target.Sha, gitObject.Sha, StringComparison.Ordinal);
+                if (equals && hashSet.Add(parent.Sha))
+                {
+                    queue.Enqueue(parent);
+                }
+
+                dequeue = dequeue || equals;
+            }
+
+            if (!dequeue)
+            {
+                break;
+            }
+        }
+
+        return commit.Sha;
+    }
+
+    private async Task<TargetLanguage[]> GetTargetLanguages(string repositoryPath, SourceLanguage sourceLanguage)
+    {
+        List<TargetLanguage> result = new(this.targetLanguageCodes.Length);
+        foreach (string targetLanguageCode in this.targetLanguageCodes)
+        {
+            string directoryPath = Path.Combine(repositoryPath, "docs", $"{targetLanguageCode}.generated");
+            string cacheFilePath = Path.Combine(repositoryPath, ".translation-tool", $"{sourceLanguage.Code}-{targetLanguageCode}-cache.json");
+            TargetLanguage targetLanguage = new(sourceLanguage, targetLanguageCode, directoryPath, cacheFilePath);
+            targetLanguage.Files = await this.GetTargetFiles(sourceLanguage, targetLanguage).ConfigureAwait(false);
+            result.Add(targetLanguage);
+        }
+
+        return result.ToArray();
+    }
+
+    private async Task<TargetFile[]> GetTargetFiles(SourceLanguage sourceLanguage, TargetLanguage targetLanguage)
+    {
+        List<TargetFile> result = new(sourceLanguage.Files.Length);
+        foreach (SourceFile sourceFile in sourceLanguage.Files)
+        {
+            string targetFilePath = sourceFile.FilePath.Replace(sourceFile.Language.DirectoryPath, targetLanguage.DirectoryPath, StringComparison.OrdinalIgnoreCase);
+            string? latestCommitFromFileHeader = await this.GetLatestCommitFromFileHeader(targetFilePath).ConfigureAwait(false);
+            if (latestCommitFromFileHeader == null || !string.Equals(sourceFile.LatestCommit, latestCommitFromFileHeader, StringComparison.Ordinal))
+            {
+                result.Add(new TargetFile(sourceFile, targetLanguage, targetFilePath));
+            }
+        }
+
+        return result.ToArray();
+    }
+
+    private async Task<string?> GetLatestCommitFromFileHeader(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return null;
+        }
+
+        string content = await File.ReadAllTextAsync(filePath, this.targetEncoding).ConfigureAwait(false);
+        Match match = GetLatestCommitRegex().Match(content);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex(@"^latestCommit: *(\S+)", RegexOptions.CultureInvariant | RegexOptions.Multiline)]
+    private static partial Regex GetLatestCommitRegex();
+}

--- a/translation-tool/SourceFile.cs
+++ b/translation-tool/SourceFile.cs
@@ -1,0 +1,21 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class SourceFile
+{
+    public SourceFile(SourceLanguage language, string filePath, string latestCommit)
+    {
+        this.Language = language ?? throw new ArgumentNullException(nameof(language));
+        this.FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        this.LatestCommit = latestCommit ?? throw new ArgumentNullException(nameof(latestCommit));
+    }
+
+    public SourceLanguage Language { get; }
+
+    public string FilePath { get; }
+
+    public string LatestCommit { get; }
+
+    public string? EOL { get; set; }
+
+    public override string ToString() => this.FilePath;
+}

--- a/translation-tool/SourceLanguage.cs
+++ b/translation-tool/SourceLanguage.cs
@@ -1,0 +1,18 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class SourceLanguage
+{
+    public SourceLanguage(string code, string directoryPath)
+    {
+        this.Code = code ?? throw new ArgumentNullException(nameof(code));
+        this.DirectoryPath = directoryPath ?? throw new ArgumentNullException(nameof(directoryPath));
+    }
+
+    public string Code { get; }
+
+    public string DirectoryPath { get; }
+
+    public SourceFile[] Files { get; set; } = Array.Empty<SourceFile>();
+
+    public override string ToString() => this.Code;
+}

--- a/translation-tool/TargetFile.cs
+++ b/translation-tool/TargetFile.cs
@@ -1,0 +1,19 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class TargetFile
+{
+    public TargetFile(SourceFile sourceFile, TargetLanguage language, string filePath)
+    {
+        this.SourceFile = sourceFile ?? throw new ArgumentNullException(nameof(sourceFile));
+        this.Language = language ?? throw new ArgumentNullException(nameof(language));
+        this.FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    public SourceFile SourceFile { get; }
+
+    public TargetLanguage Language { get; }
+
+    public string FilePath { get; }
+
+    public override string ToString() => this.FilePath;
+}

--- a/translation-tool/TargetLanguage.cs
+++ b/translation-tool/TargetLanguage.cs
@@ -1,0 +1,24 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class TargetLanguage
+{
+    public TargetLanguage(SourceLanguage sourceLanguage, string code, string directoryPath, string cacheFilePath)
+    {
+        this.SourceLanguage = sourceLanguage ?? throw new ArgumentNullException(nameof(sourceLanguage));
+        this.Code = code ?? throw new ArgumentNullException(nameof(code));
+        this.DirectoryPath = directoryPath ?? throw new ArgumentNullException(nameof(directoryPath));
+        this.CacheFilePath = cacheFilePath ?? throw new ArgumentNullException(nameof(cacheFilePath));
+    }
+
+    public SourceLanguage SourceLanguage { get; }
+
+    public string Code { get; }
+
+    public string DirectoryPath { get; }
+
+    public string CacheFilePath { get; }
+
+    public TargetFile[] Files { get; set; } = Array.Empty<TargetFile>();
+
+    public override string ToString() => this.Code;
+}

--- a/translation-tool/TextSubstitution.cs
+++ b/translation-tool/TextSubstitution.cs
@@ -1,0 +1,23 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+internal sealed class TextSubstitution : ISubstitution
+{
+    private readonly string text;
+    private readonly IDictionary<int, ISubstitution> substitutions;
+
+    public TextSubstitution(string text, IDictionary<int, ISubstitution> substitutions)
+    {
+        this.text = text ?? throw new ArgumentNullException(nameof(text));
+        this.substitutions = substitutions ?? throw new ArgumentNullException(nameof(substitutions));
+    }
+
+    public string GetReplacement() => DeeplIgnoreTag.GetSubstitutionRegex().Replace(this.text, this.ApplySubstitutions);
+
+    private string ApplySubstitutions(Match match) =>
+        int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int index) &&
+        this.substitutions.TryGetValue(index, out ISubstitution? substitution) ?
+            substitution.GetReplacement() : match.Value;
+}

--- a/translation-tool/TranslatedFileCounter.cs
+++ b/translation-tool/TranslatedFileCounter.cs
@@ -1,0 +1,21 @@
+﻿namespace Devolutions.TranslationTool;
+
+internal sealed class TranslatedFileCounter
+{
+    private readonly int maximum;
+    private int current;
+
+    public TranslatedFileCounter(int maximum)
+    {
+        this.maximum = maximum;
+        this.MaximumReached = this.current >= this.maximum;
+    }
+
+    public bool MaximumReached { get; private set; }
+
+    public void Increment()
+    {
+        this.current++;
+        this.MaximumReached = this.current >= this.maximum;
+    }
+}

--- a/translation-tool/TranslationSubstitution.cs
+++ b/translation-tool/TranslationSubstitution.cs
@@ -1,0 +1,35 @@
+﻿namespace Devolutions.TranslationTool;
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+internal sealed class TranslationSubstitution : ISubstitution
+{
+    private readonly DeeplTranslation translation;
+    private readonly IList<int> substitutionIndexes;
+    private readonly IDictionary<int, ISubstitution> substitutions;
+
+    public TranslationSubstitution(DeeplTranslation translation, IList<int> substitutionIndexes, IDictionary<int, ISubstitution> substitutions)
+    {
+        this.translation = translation ?? throw new ArgumentNullException(nameof(translation));
+        this.substitutionIndexes = substitutionIndexes ?? throw new ArgumentNullException(nameof(substitutionIndexes));
+        this.substitutions = substitutions ?? throw new ArgumentNullException(nameof(substitutions));
+    }
+
+    public string GetReplacement()
+    {
+        string? result = this.translation.Result;
+        if (result == null)
+        {
+            throw new InvalidOperationException("Translations must be done before calling for replacements");
+        }
+
+        return DeeplIgnoreTag.GetSubstitutionRegex().Replace(result, this.ApplySubstitutions);
+    }
+
+    private string ApplySubstitutions(Match match) =>
+        int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out int index) &&
+        index < this.substitutionIndexes.Count &&
+        this.substitutions.TryGetValue(this.substitutionIndexes[index], out ISubstitution? substitution) ?
+            substitution.GetReplacement() : match.Value;
+}


### PR DESCRIPTION
* Testé avec 20 fichiers. Les résultats me semblent concluants. Certaines traductions sont douteuses, mais c'est DeepL, pas moi. Notamment Devolutions. Faudra jouer avec le glossaire j'imagine pour ça.
* Je n'ai pas essayé de convertir tous les fichiers d'un coup, j'hésite comme je ne sais pas trop comment l'API DeepL va réagir.
* Techniquement, c'est un call API par fichier.
* Lancez le programme sans argument pour connaître les options. Techniquement, la clé DeepL est obligatoire donc ça affiche les options lorsqu'elle est omise.
* Si la clé est spécifiée sans changer rien d'autre, ça va tout traduire de "en" à "fr". Sinon, c'est possible d'y aller un plus petit nombre de fichiers à la fois avec l'option -m. Ça ne reprendra pas les mêmes fichiers d'exécution en exécution à cause du lastestCommit ajouté à l'entête des fichiers générés.
* À noter que le dossier courant, lorsque le programme est appelé, doit se trouver dans la repository doc. Ça peut être un sous-dossier sans problème.
* À noter qu'une cache en mémoire vive (un Dictionary) existe pour éviter que la même traduction soit demandée plus qu'une fois à DeepL, pour réduire le volume des appels à l'API de DeepL.
* À noter aussi qu'une cache locale sur le disque (un fichier Json) est mise à jour après l'écriture de chaque fichier, ce qui est utile quand on fait des exécutions successives du programme, pour encore une fois réduire le volume des appels à l'API de DeepL. Vous pouvez supprimer cette cache en supprimant le dossier ".translation-tool" (avec le . en avant).
* Finalement, dernière note, en .NET 7, les Regex compilées à la compilation du programme existent maintenant. C'est ce que j'ai utilisé pour maximiser les performances. Ça l'a aussi l'avantage que quand on "hover" au-dessus de la méthode partielle qui représente la Regex, ça décrit le pattern de la Regex.