### PR TITLE
Added -f (--force) option

### DIFF
--- a/translation-tool/FileTranslator.cs
+++ b/translation-tool/FileTranslator.cs
@@ -78,6 +78,8 @@ internal sealed partial class FileTranslator
         this.translations = new Dictionary<string, DeeplTranslation>(TranslationsInitialCapacity, StringComparer.Ordinal);
         this.substitutions = new Dictionary<int, ISubstitution>(SubstitutionsInitialCapacity);
         string latestCommitHeaderLine = $"latestCommit: {this.targetFile.SourceFile.LatestCommit}{this.sourceFileEOL}";
+        string glossaryIDHeaderLine = this.targetFile.Language.GlossaryID != null ?
+            $"glossaryID: {this.targetFile.Language.GlossaryID}{this.sourceFileEOL}" : string.Empty;
         Match headerMatch = GetHeaderRegex().Match(this.sourceFileContent);
         if (headerMatch.Success)
         {
@@ -90,13 +92,13 @@ internal sealed partial class FileTranslator
             targetFileHeaderPart1 = DescriptionLineRegex().Replace(targetFileHeaderPart1, this.ReplaceDescriptionLineRegex, 1);
             targetFileHeaderPart1 = KeywordsLinesRegex().Replace(targetFileHeaderPart1, this.ReplaceKeywordsLinesRegex, 1);
             targetFileHeaderPart1 = LatestCommitLineRegex().Replace(targetFileHeaderPart1, this.sourceFileEOL, 1);
-
-            this.targetFileHeader = $"{targetFileHeaderPart1}{latestCommitHeaderLine}{sourceFileHeaderPart2}";
+            targetFileHeaderPart1 = GlossaryIDRegex().Replace(targetFileHeaderPart1, this.sourceFileEOL, 1);
+            this.targetFileHeader = $"{targetFileHeaderPart1}{latestCommitHeaderLine}{glossaryIDHeaderLine}{sourceFileHeaderPart2}";
         }
         else
         {
             this.sourceFileContentWithoutHeader = this.sourceFileContent;
-            this.targetFileHeader = $"---{this.sourceFileEOL}{latestCommitHeaderLine}---{this.sourceFileEOL}";
+            this.targetFileHeader = $"---{this.sourceFileEOL}{latestCommitHeaderLine}{glossaryIDHeaderLine}---{this.sourceFileEOL}";
         }
     }
 
@@ -165,6 +167,9 @@ internal sealed partial class FileTranslator
 
     [GeneratedRegex(@"(?:\r?\n|\r) *latestCommit:[^\r\n]*(?:\r?\n|\r)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
     private static partial Regex LatestCommitLineRegex();
+
+    [GeneratedRegex(@"(?:\r?\n|\r) *glossaryID:[^\r\n]*(?:\r?\n|\r)", RegexOptions.CultureInvariant | RegexOptions.Singleline)]
+    private static partial Regex GlossaryIDRegex();
 
     private async Task ParseSourceFile()
     {

--- a/translation-tool/ProgramOptions.cs
+++ b/translation-tool/ProgramOptions.cs
@@ -24,7 +24,7 @@ public sealed class ProgramOptions
     [Option('m', "max", Required = false, Default = int.MaxValue, HelpText = "Maximum translated file count")]
     public int MaxTranslatedFileCount { get; set; }
 
-    [Option('f', "force", Required = false, Default = false, HelpText = "Translates files that were generated with a different Glossary ID even if the files themselves have not changed")]
+    [Option('f', "force", Required = false, Default = false, HelpText = "Translates files that were generated using a different Glossary ID even if the source files themselves have not changed")]
     public bool Force { get; set; }
 
     public string? GetGlossaryID(string sourceLanguageCode, string targetLanguageCode) =>

--- a/translation-tool/ProgramOptions.cs
+++ b/translation-tool/ProgramOptions.cs
@@ -24,7 +24,7 @@ public sealed class ProgramOptions
     [Option('m', "max", Required = false, Default = int.MaxValue, HelpText = "Maximum translated file count")]
     public int MaxTranslatedFileCount { get; set; }
 
-    [Option('f', "force", Required = false, Default = false, HelpText = "Translates files that were generated using a different Glossary ID even if the source files themselves have not changed")]
+    [Option('f', "force", Required = false, Default = false, HelpText = "Translates files that were translated using a different Glossary ID even if they have not been modified")]
     public bool Force { get; set; }
 
     public string? GetGlossaryID(string sourceLanguageCode, string targetLanguageCode) =>

--- a/translation-tool/ProgramOptions.cs
+++ b/translation-tool/ProgramOptions.cs
@@ -24,6 +24,9 @@ public sealed class ProgramOptions
     [Option('m', "max", Required = false, Default = int.MaxValue, HelpText = "Maximum translated file count")]
     public int MaxTranslatedFileCount { get; set; }
 
+    [Option('f', "force", Required = false, Default = false, HelpText = "Translates files that were generated with a different Glossary ID even if the files themselves have not changed")]
+    public bool Force { get; set; }
+
     public string? GetGlossaryID(string sourceLanguageCode, string targetLanguageCode) =>
         string.Equals(sourceLanguageCode, LanguageCode.English, StringComparison.OrdinalIgnoreCase) ?
             string.Equals(targetLanguageCode, LanguageCode.French, StringComparison.OrdinalIgnoreCase) ? this.EnFrGlossaryID :

--- a/translation-tool/StringExtensions.cs
+++ b/translation-tool/StringExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Devolutions.TranslationTool;
+
+public static class StringExtensions
+{
+    public static string? NullIfEmpty(this string? value) =>
+        value is { Length: > 0 } ? value : null;
+}


### PR DESCRIPTION
When true, this option translates files that were generated with a different Glossary ID even if the files themselves have not changed. Added glossaryID header line to generated files.
![image](https://github.com/Devolutions/doc/assets/79470757/765712ae-2557-4998-8f35-46b0e0a65261)
