### PR TITLE
Translation tool fix

### DIFF
--- a/translation-tool/FileTranslator.cs
+++ b/translation-tool/FileTranslator.cs
@@ -209,7 +209,7 @@ internal sealed partial class FileTranslator
     private string ReplaceLink(Match match)
     {
         string link = match.Groups[2].Value;
-        if (link.StartsWith("!!", StringComparison.Ordinal) || link.Length > 4 && link[^4] == '.')
+        if (link.StartsWith("!!", StringComparison.Ordinal))
         {
             // This is a filename, do not translate
             return this.AddTextSubstitution(match.Value);

--- a/translation-tool/FileTranslator.cs
+++ b/translation-tool/FileTranslator.cs
@@ -211,7 +211,7 @@ internal sealed partial class FileTranslator
         string link = match.Groups[2].Value;
         if (link.StartsWith("!!", StringComparison.Ordinal))
         {
-            // This is a filename, do not translate
+            // A link name starting with !! will not be rendered, do not translate it
             return this.AddTextSubstitution(match.Value);
         }
 


### PR DESCRIPTION
* Always translate A in link `![A](B)` or `[A](B)` unless A starts with !!