### PR TITLE
Remove references to Portal for custom installers 

### DIFF
--- a/docs/en/rdm/windows/installation/client/custom-installer-service/index.md
+++ b/docs/en/rdm/windows/installation/client/custom-installer-service/index.md
@@ -1,25 +1,20 @@
 ---
 eleventyComputed:
   title: "{{ en.CIS }}"
-  description: "The {{ en.CIS }} offered through our Devolutions Customer Portal services replicates the configuration from a {{ en.RDM }} instance."
+  description: "The {{ en.CIS }} generates custom installation packages for {{ en.RDM }}."
 ---
 ![!!CustomInstallerServiceIcon](https://webdevolutions.azureedge.net/images/projects/custom-installer/logos/custom-installer-white-shadow.svg)
 
-* Generate and download custom installation packages for {{ en.RDM }}.
+* Generate custom installation packages for {{ en.RDM }}.
 * Include preconfigured data sources in the package for quick enterprise wide deployment.
-* Download the installer as a Windows Installer (.msi file).
 
-The {{ en.CIS }} offered through our Devolutions Customer Portal services replicates the configuration from a {{ en.RDM }} instance. This configuration is used to create an installer file (*.rdi), which will be used to create the installation package intended for distribution. The configuration can contain data sources, credentials, database templates, and more. It is best practice to have a {{ en.RDM }} installation used specifically to create the installation package.
+The {{ en.CIS }} replicates the configuration from a {{ en.RDM }} instance. This configuration is used to create an installer file (*.rdi), which will be used to create the installation package intended for distribution. The configuration can contain data sources, credentials, database templates, and more. It is best practice to have a {{ en.RDM }} installation used specifically to create the installation package.
 
 {% snippet icon.shieldWarning %}
 The ***No Internet connection*** option in {{ en.RDM }} (***File*** – ***Option*** – ***Tools*** – ***Advanced***) must be disabled for {{ en.CI }} to work.
 {% endsnippet %}
 
-{% snippet icon.shieldInfo %}
-The {{ en.CIS }} uploads a configuration file to our online services. You should not use the service to redistribute passwords for data sources.
-{% endsnippet %}
-
-You **must create an installer file** using {{ en.RDM }} before creating the installer on the Web portal. This is described in [Installer File Generator](/rdm/windows/installation/client/custom-installer-service/installer-file-generator/).
+You **must create an installer file** using {{ en.RDM }} before creating the installer. This is described in [Installer File Generator](/rdm/windows/installation/client/custom-installer-service/installer-file-generator/).
 
 The {{ en.CIS }} can be found in with the {{ en.DA }} tools, located in ***File – {{ en.DA }} – Tools***. You must be signed in to access it.
 ![File – {{ en.DA }} – Tools](https://webdevolutions.azureedge.net/docs/en/rdm/windows/clip11245.png)

--- a/docs/fr/rdm/windows/installation/client/custom-installer-service/index.md
+++ b/docs/fr/rdm/windows/installation/client/custom-installer-service/index.md
@@ -9,21 +9,16 @@ eleventyComputed:
 ![!!CustomInstallerServiceIcon](https://webdevolutions.azureedge.net/docs/fr/rdm/windows/CustomInstallerServiceIcon.png)
 		</td>
 		<td>
-* Générer et télécharger des paquets d'installation personnalisés pour {{ fr.RDM }}.
+* Générer des paquets d'installation personnalisés pour {{ fr.RDM }}.
 * Inclure des sources de données préconfigurées dans le paquet pour un déploiement rapide à l'échelle de l'entreprise.
-* Télécharger le programme d'installation en tant que Windows Installer (fichier .msi).
 		</td>
 	</tr>
 </table>
 
-Le {{ fr.CIS }}, proposé à partir de nos services {{ fr.DC }}, reproduit la configuration à partir d'une instance de {{ fr.RDM }}. Cette configuration est utilisée pour créer un fichier d'installation (*.rdi) qui sera utilisé pour créer le paquet d'installation destiné à la distribution. La configuration peut contenir les sources de données, les informations d'identifiants, les modèles de base de données et plus encore. Il est recommandé d'utiliser une installation type de {{ fr.RDM }} pour créer le paquet d'installation.
-
-{% snippet icon.shieldWarning %}
-Le {{ fr.CIS }} télécharge un fichier de configuration sur nos services en ligne. Vous ne devez pas utiliser le service pour redistribuer des mots de passe pour des sources de données.
-{% endsnippet %}
+Le {{ fr.CIS }} reproduit la configuration à partir d'une instance de {{ fr.RDM }}. Cette configuration est utilisée pour créer un fichier d'installation (*.rdi) qui sera utilisé pour créer le paquet d'installation destiné à la distribution. La configuration peut contenir les sources de données, les informations d'identifiants, les modèles de base de données et plus encore. Il est recommandé d'utiliser une installation type de {{ fr.RDM }} pour créer le paquet d'installation.
 
 {% snippet icon.badgeInfo %}
-Vous devez créer un fichier d'installation à l'aide de {{ fr.RDM }} avant de créer l'installateur sur le portail Web. Cette procédure est décrite dans [Générateur de fichier de configuration](/fr/rdm/windows/installation/client/custom-installer-service/installer-file-generator/).
+Vous devez créer un fichier d'installation à l'aide de {{ fr.RDM }} avant de créer l'installateur. Cette procédure est décrite dans [Générateur de fichier de configuration](/fr/rdm/windows/installation/client/custom-installer-service/installer-file-generator/).
 {% endsnippet %}
 
 {% snippet icon.badgeInfo %}


### PR DESCRIPTION
@hmireault-devo 

J'ai retiré les références à Portal sur la page https://docs.devolutions.net/rdm/windows/installation/client/custom-installer-service/ comme les installers sont générés localement maintenant. Il reste la page en allemand à modifier.