### PR TITLE
Update system-requirements.md

### DIFF
--- a/docs/content/en/server/dgw/system-requirements.md
+++ b/docs/content/en/server/dgw/system-requirements.md
@@ -26,7 +26,7 @@ One {{ en.DGW }} can handle up to 75 concurrent sessions with good performance.
 
 ### Prerequisites
 
-* {{ en.DVLS }} Team, Enterprise, or Platinum Edition.
+* {{ en.DVLS }} Free, Team, Enterprise, or Platinum Edition.
 * A license is required for each deployed {{ en.DGW }}. Contact our [sales department](mailto:sales@devolutions.net) for more information.
     * If {{ en.DGW }} is installed side by side with {{ en.DVLS }} on the same server, it supports up to 5 concurrent sessions without a license.
 * For MSPs, one {{ en.DGW }} can be deployed per customer site.  All you need is to keep the {{ en.DGW }} servers reachable by both {{ en.DVLS }} and {{ en.RDM }}. {{ en.DGW }} only needs to accept inbound connections coming from them. No outbound connections to {{ en.DVLS }} and {{ en.RDM }} are required.


### PR DESCRIPTION
Added "Free" to prereqs as DVLS Free can use Gateway with up to 5 concurrent sessions.