### PR TITLE
Update group-policies.md

### DIFF
--- a/docs/content/en/rdm/kb/rdm-windows/how-to-articles/group-policies.md
+++ b/docs/content/en/rdm/kb/rdm-windows/how-to-articles/group-policies.md
@@ -485,11 +485,6 @@ If {{ en.RDM }} is open when you make this change, then you will need to restart
 
 ---
 
-#### Disable the {{ en.DVLSCONSOLE }} in the Tools menu
-`%Root%\SOFTWARE\Policies\Devolutions\RemoteDesktopManager\DisableToolsDevolutionsServerConsole`
-
----
-
 #### Disable the Error Report prompt
 `%Root%\SOFTWARE\Policies\Devolutions\RemoteDesktopManager\DisableSendErrorReportDialog`
 


### PR DESCRIPTION
J'ai retiré la licgne concernant le bouton DVLS Console dans le menu Tools de RDM. Ce bouton n'existe plus depuis la version 2019 de RDM et l'équipe RDM va le retirer du code.